### PR TITLE
Add pygmalion-7b, remove Erebus and Alpaca

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -32,7 +32,7 @@ export default {
   // A comma separated list of models to use
   CHATBOT_MODELS:
     env.get("CHATBOT_MODELS").asString() ??
-    "PygmalionAI/pygmalion-6b,KoboldAI/OPT-13B-Erebus,Alpaca-30B-Int4-128G",
+    "PygmalionAI/pygmalion-6b,PygmalionAI/pygmalion-7b",
   CHATBOT_LIMITER: env.get("CHATBOT_LIMITER").asString() ?? "<CLEAR>",
   CHATBOT_REACTION: env.get("CHATBOT_REACTION").asString() ?? "⌛",
 };


### PR DESCRIPTION
Added Pygmalion's 7B model as an alternative model in case people start hosting it more.
Removed Erebus due to the lack of hosting.
Removed Alpaca due to the model being renamed, and lack of hosting.